### PR TITLE
Fixes to limit files included in npm publish tarball and pass tirekick test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,5 +50,5 @@ jobs:
           name: Run tirekick Integration test
           command: yarn tirekick
           environment:
-            FUNCTION_RESOURCE: http://basic-puffin-6927.descriptive-turnip-7558.morning-ocean-4277.herokuspace.com
+            FUNCTION_RESOURCE: http://fitted-rattlesnake-5922.still-coconut-4422.blooming-dawn-7421.herokuspace.com
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,5 +50,5 @@ jobs:
           name: Run tirekick Integration test
           command: yarn tirekick
           environment:
-            FUNCTION_RESOURCE: http://fitted-rattlesnake-5922.still-coconut-4422.blooming-dawn-7421.herokuspace.com
+            FUNCTION_RESOURCE: http://basic-puffin-6927.descriptive-turnip-7558.morning-ocean-4277.herokuspace.com
 

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,10 @@
+DEVELOPING.md
+.circleci
+.eslint*
 lib/
+.prettierrc
+.sfdx-dev.*
+src/
+*.tgz
 tsconfig.json
 tslint.json
-.prettierrc

--- a/.sfdx-dev.json
+++ b/.sfdx-dev.json
@@ -1,6 +1,7 @@
 {
   "clean": {
     "skipDefaults": false,
-    "dirs": ["dist"]
+    "dirs": ["dist"],
+    "files": ["*.tgz"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "nyc --extension .ts mocha --forbid-only -r ts-node/register 'test/unit/**/*.ts'",
     "test-all": "mocha -r ts-node/register 'test/**/*.ts'",
     "test-integration": "mocha -r ts-node/register 'test/integration/**/*.ts'",
-    "tirekick": "mocha --timeout 10000 -r ts-node/register 'test/integration/functions/InvokeFunctionIntegrationTests.ts'",
+    "tirekick": "mocha --timeout 60000 -r ts-node/register 'test/integration/functions/InvokeFunctionIntegrationTests.ts'",
     "version": "npm run format && git add -A src",
     "watch-ts": "tsc -w"
   },

--- a/test/integration/functions/InvokeFunctionIntegrationTests.ts
+++ b/test/integration/functions/InvokeFunctionIntegrationTests.ts
@@ -12,6 +12,7 @@ const functionResource: string = process.env.FUNCTION_RESOURCE || 'http://system
 const functionRequestBody: string = process.env.FUNCTION_REQUEST_BODY;
 const functionRequestBodyFilePath: string = process.env.FUNCTION_REQUEST_BODY_FILEPATH || path.join(__dirname, 'hello-payload.json');
 const functionRequestBodyUrl: string = process.env.FUNCTION_REQUEST_BODY_URL;
+const functionRequestTimeout: number = parseInt(process.env.FUNCTION_REQUEST_TIMEOUT || '60000');
 
 describe('Invoke Function Integration Tests', () => {
 
@@ -33,7 +34,7 @@ describe('Invoke Function Integration Tests', () => {
             json: true, // Automatically parses the JSON string in the response
             method: 'POST',
             resolveWithFullResponse: true,
-            timeout: 10000,
+            timeout: functionRequestTimeout,
             uri: functionResource,
         };
 


### PR DESCRIPTION
Exclude build/config artifacts from `npm pack` or `npm publish` tarball:
- DEVELOPING readme
- CircleCI config
- ESLint config
- SFDX Dev scripts config
- npm pack tarball

Ensure npm pack tarball is cleaned up on a `yarn clean`.

Extended request and mocha timeouts in `tirekick` test, request timeout configurable with `FUNCTION_REQUEST_TIMEOUT` env var (default 60000 == 1min)