### PR TITLE
Log secrets load errors ONLY at debug level - log.info was excessive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/salesforce-sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Salesforce SDK for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api/Secrets.ts
+++ b/src/api/Secrets.ts
@@ -66,7 +66,7 @@ class CacheEntry {
             }
         } catch (reason) {
             // hide dir stat/listing error from caller, just log and return back w/undefined values
-            logger.info(`Failed secret ${secretName} dir listing: ${reason}`);
+            logger.debug(`Failed secret ${secretName} dir listing: ${reason}`);
         }
         return new CacheEntry(secretName, now, undefined, undefined);
     }


### PR DESCRIPTION
Related to
* W-7379871
* https://gus.my.salesforce.com/a07B0000008BAB9IAO

Excessive log output.

Prep for bugfix release 1.1.2.

