### PR TITLE
Change ReferenceId to an interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Change ReferenceID to an interface ([#98](https://github.com/forcedotcom/sf-fx-sdk-nodejs/pull/98))
+
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### 3.0.0
+
 - Change ReferenceID to an interface ([#98](https://github.com/forcedotcom/sf-fx-sdk-nodejs/pull/98))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 3.0.0
 
 - Change ReferenceID to an interface ([#98](https://github.com/forcedotcom/sf-fx-sdk-nodejs/pull/98))
-
-### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-sdk-nodejs",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "Salesforce SDK for Node.js",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,11 @@ export interface RecordModificationResult {
 /**
  * References a record that will be created, deleted or modified in the future.
  */
-export type ReferenceId = string;
+export interface ReferenceId {
+  readonly id: string;
+  toString(): string;
+  toApiString(): string;
+};
 
 /**
  * Creates a single record for create or registers a record creation for the {@link UnitOfWork}

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,11 +107,24 @@ export interface RecordModificationResult {
 }
 
 /**
- * References a record that will be created, deleted or modified in the future.
+ * References a modification, creation, or deletion of an object that may
+ * occur as a part of a UnitOfWork.
  */
 export interface ReferenceId {
-  readonly id: string;
+  /**
+   * Get a reference to a record modification, creation, or deletion that may
+   * occur as a part of a UnitOfWork.
+   *
+   * @returns A string identifier
+   */
   toString(): string;
+
+  /**
+   * Get a reference to a record's ID that may be created, deleted, or modified
+   * as part of a UnitOfWork.
+   *
+   * @returns A string reference to a record id
+   */
   toApiString(): string;
 };
 


### PR DESCRIPTION
In order to work with the composite API, we need to access ReferenceIds in two ways:
- The temporary reference id like "someobject1"
- A reference to remote object id like "@{someobject1.id}"

This interface is similar to what we have in the java sdk: https://github.com/forcedotcom/sf-fx-runtime-java/blob/main/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/ReferenceIdImpl.java#L19-L21