### PR TITLE
Switch Dependabot to weekly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
Since for this repository in particular, some of the dependencies have a particularly high
churn rate, sometimes with multiple releases in the same week.

By setting Dependabot to weekly, it means the interim releases can be skipped.

(Otherwise normally `daily` means less pain from conflicts/rebases, since the same number
of PRs are spread throughout the week.)

GUS-W-9981100.